### PR TITLE
chore: update docs.editUrl on docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -96,7 +96,7 @@ module.exports = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           editUrl:
-            "https://github.com/paymentsds/docs/blob/master/",
+            "https://github.com/paymentsds/docs/edit/master/",
         },
         blog: {
           showReadingTime: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -96,7 +96,7 @@ module.exports = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           editUrl:
-            "https://github.com/facebook/docusaurus/edit/master/website/",
+            "https://github.com/paymentsds/docs/blob/master/",
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
The "Edit this page" button at the bottom of the [docs](http://developers.paymentsds.org/docs/) incorrectly redirects to https://github.com/facebook/docusaurus/edit/master/website/docs/doc1.md , which shows a 404 error.

This PR should fix the link on the docs to point to the correct file on this repo: https://github.com/paymentsds/docs/blob/master/docs/doc1.md